### PR TITLE
Don't specify chrome path when getting link

### DIFF
--- a/src/pocket_save.py
+++ b/src/pocket_save.py
@@ -59,10 +59,10 @@ def get_browser_link(browser):
     url = title = None
     if browser == 'Google Chrome':
         url = os.popen("osascript -e 'tell application "
-                       "\"/Applications/Google Chrome.app\" to return URL of "
+                       "\"Google Chrome\" to return URL of "
                        "active tab of front window'").readline()
         title = os.popen("osascript -e 'tell application "
-                         "\"/Applications/Google Chrome.app\" to return title "
+                         "\"Google Chrome\" to return title "
                          "of active tab of front window'").readline()
     elif browser == 'Safari':
         url = os.popen("osascript -e 'tell application "


### PR DESCRIPTION
Saving the link from the current tab open in Chrome doesn't work if Chrome is installed in a location other than `/Applications/Google Chrome.app`.

Fix it by using the plain `"Google Chrome"` application identifier to get the URL and title from Chrome